### PR TITLE
Kernel repetitions

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,9 +1,11 @@
 /* This project is licensed under the terms of the Creative Commons CC BY-NC-ND 4.0 license. */
 
 #include <algorithm>
+#include <chrono>
 #include <fstream>
 #include <iostream>
 #include <math.h>
+#include <sstream>
 #include <string>
 #include <thread>
 #include <vector>
@@ -13,9 +15,6 @@
 #include "hdf5_io.hpp"
 #include "ocl_dev_mgr.hpp"
 #include "timer.hpp"
-#include <chrono>
-#include <sstream> 
-#include <fstream>
 
 using namespace std;
 
@@ -27,21 +26,21 @@ typedef LONG NTSTATUS, *PNTSTATUS;
 typedef NTSTATUS(WINAPI* RtlGetVersionPtr)(PRTL_OSVERSIONINFOEXW);
 
 RTL_OSVERSIONINFOEXW GetRealOSVersion() {
-	HMODULE hMod = ::GetModuleHandleW(L"ntdll.dll");
-	if (hMod) {
-		RtlGetVersionPtr fxPtr = (RtlGetVersionPtr)::GetProcAddress(hMod, "RtlGetVersion");
-		if (fxPtr != nullptr) {
-			RTL_OSVERSIONINFOEXW  rovi = { 0 };
-			rovi.dwOSVersionInfoSize = sizeof(rovi);
-			if (STATUS_SUCCESS == fxPtr(&rovi)) {
-				return rovi;
-			}
-				
-			}
-		}
+  HMODULE hMod = ::GetModuleHandleW(L"ntdll.dll");
+  if (hMod) {
+    RtlGetVersionPtr fxPtr = (RtlGetVersionPtr)::GetProcAddress(hMod, "RtlGetVersion");
+    if (fxPtr != nullptr) {
+      RTL_OSVERSIONINFOEXW  rovi = { 0 };
+      rovi.dwOSVersionInfoSize = sizeof(rovi);
+      if (STATUS_SUCCESS == fxPtr(&rovi)) {
+        return rovi;
+      }
 
-	RTL_OSVERSIONINFOEXW rovi = { 0 };
-	return rovi;
+      }
+    }
+
+  RTL_OSVERSIONINFOEXW rovi = { 0 };
+  return rovi;
 }
 #else
 #include <sys/utsname.h>
@@ -49,19 +48,17 @@ RTL_OSVERSIONINFOEXW GetRealOSVersion() {
 
 std::string getOS()
 {
-	std::stringstream version;
+  std::stringstream version;
 #if defined(_WIN32)
 
-	version<<"Windows " << GetRealOSVersion().dwMajorVersion<<"."<< GetRealOSVersion().dwMinorVersion;
-	
-	if (GetRealOSVersion().wProductType == VER_NT_WORKSTATION) {
-		version << " Workstation";
-	}
-	else {
-		version << " Server";
-	}
+  version<<"Windows " << GetRealOSVersion().dwMajorVersion<<"."<< GetRealOSVersion().dwMinorVersion;
 
-
+  if (GetRealOSVersion().wProductType == VER_NT_WORKSTATION) {
+    version << " Workstation";
+  }
+  else {
+    version << " Server";
+  }
 
 #else
 
@@ -75,21 +72,21 @@ version<<unameData.sysname<<" ";
   if (rel_file.is_open())
   {
   for ( unsigned int i=0; i<5;i++)
-   { 
+   {
      getline (rel_file,line);
      }
-     
+
       version << line.substr(13,line.length()-14);
-    
+
     rel_file.close();
   }
 version<<"/"<<unameData.release<<"/"<<unameData.version;
 
 #endif
 
-	return version.str();
-
+  return version.str();
 }
+
 
 // command line arguments
 char const* getCmdOption(char** begin, char** end, std::string const& option)
@@ -154,8 +151,8 @@ int main(int argc, char *argv[]) {
 
   string kernel_url;
   if (h5_check_object(filename, "Kernel_URL") == true) {
-	  h5_read_string(filename, "Kernel_URL", kernel_url);
-	  cout << "Reading kernel from file: " << kernel_url << "... " << endl;
+    h5_read_string(filename, "Kernel_URL", kernel_url);
+    cout << "Reading kernel from file: " << kernel_url << "... " << endl;
   }
   else if (h5_check_object(filename, "Kernel_Source") == true) {
     cout << "Reading kernel from HDF5 file... " << endl;
@@ -180,12 +177,15 @@ int main(int argc, char *argv[]) {
 
   cl_ulong kernel_repetitions = 1;
   if (h5_check_object(filename, "Kernel_Repetitions")) {
-	  kernel_repetitions = h5_read_single<cl_ulong>(filename, "Kernel_Repetitions");
+    kernel_repetitions = h5_read_single<cl_ulong>(filename, "Kernel_Repetitions");
+  }
+  if (kernel_repetitions <= 0) {
+    cout << "Warning: Setting `kernel_repetitions = " << kernel_repetitions << "` implies that no kernels are executed." << endl;
   }
 
   dev_mgr.add_program_url(0, "ocl_Kernel", kernel_url);
 
-	string settings;
+  string settings;
   h5_read_string(filename, "Kernel_Settings", settings);
 
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -24,8 +24,15 @@ foreach(TEST ${TIMER_TEST})
 endforeach()
 
 
+# kernel repetition test
+set(KERNEL_REPETITION_TEST repetition_test)
+foreach(TEST ${KERNEL_REPETITION_TEST})
+  add_executable(${TEST} ${TEST}.cpp ../include/opencl_include.hpp ../include/util.hpp ../include/hdf5_io.hpp ../src/hdf5_io.cpp)
+endforeach()
+
+
 # all tests
-set(TESTS ${COPY_TESTS} ${TIMER_TEST})
+set(TESTS ${COPY_TESTS} ${TIMER_TEST} ${KERNEL_REPETITION_TEST})
 
 foreach(TEST ${TESTS})
   target_link_libraries(${TEST} ${OpenCL_LIBRARIES} ${HDF5_HL_LIBRARIES} ${HDF5_LIBRARIES})

--- a/test/copy_char.cpp
+++ b/test/copy_char.cpp
@@ -1,4 +1,4 @@
-/* TODO: Provide a license note */
+/* This project is licensed under the terms of the Creative Commons CC BY-NC-ND 4.0 license. */
 
 #define COPYTYPE cl_char
 #define COPYTYPE_CL char

--- a/test/copy_double.cpp
+++ b/test/copy_double.cpp
@@ -1,4 +1,4 @@
-/* TODO: Provide a license note */
+/* This project is licensed under the terms of the Creative Commons CC BY-NC-ND 4.0 license. */
 
 #define COPYTYPE double
 #define COPYTYPE_CL double

--- a/test/copy_float.cpp
+++ b/test/copy_float.cpp
@@ -1,4 +1,4 @@
-/* TODO: Provide a license note */
+/* This project is licensed under the terms of the Creative Commons CC BY-NC-ND 4.0 license. */
 
 #define COPYTYPE float
 #define COPYTYPE_CL float

--- a/test/copy_int.cpp
+++ b/test/copy_int.cpp
@@ -1,4 +1,4 @@
-/* TODO: Provide a license note */
+/* This project is licensed under the terms of the Creative Commons CC BY-NC-ND 4.0 license. */
 
 #define COPYTYPE cl_int
 #define COPYTYPE_CL int

--- a/test/copy_long.cpp
+++ b/test/copy_long.cpp
@@ -1,4 +1,4 @@
-/* TODO: Provide a license note */
+/* This project is licensed under the terms of the Creative Commons CC BY-NC-ND 4.0 license. */
 
 #define COPYTYPE cl_long
 #define COPYTYPE_CL long

--- a/test/copy_short.cpp
+++ b/test/copy_short.cpp
@@ -1,4 +1,4 @@
-/* TODO: Provide a license note */
+/* This project is licensed under the terms of the Creative Commons CC BY-NC-ND 4.0 license. */
 
 #define COPYTYPE cl_short
 #define COPYTYPE_CL short

--- a/test/copy_test.h
+++ b/test/copy_test.h
@@ -1,4 +1,4 @@
-/* TODO: Provide a license note */
+/* This project is licensed under the terms of the Creative Commons CC BY-NC-ND 4.0 license. */
 
 #ifndef COPY_TEST_H
 #define COPY_TEST_H

--- a/test/copy_test.jl
+++ b/test/copy_test.jl
@@ -1,3 +1,5 @@
+# This project is licensed under the terms of the Creative Commons CC BY-NC-ND 4.0 license.
+
 using HDF5
 
 type_to_name(::Type{Int8}) = "char"

--- a/test/copy_uchar.cpp
+++ b/test/copy_uchar.cpp
@@ -1,4 +1,4 @@
-/* TODO: Provide a license note */
+/* This project is licensed under the terms of the Creative Commons CC BY-NC-ND 4.0 license. */
 
 #define COPYTYPE cl_uchar
 #define COPYTYPE_CL uchar

--- a/test/copy_uint.cpp
+++ b/test/copy_uint.cpp
@@ -1,4 +1,4 @@
-/* TODO: Provide a license note */
+/* This project is licensed under the terms of the Creative Commons CC BY-NC-ND 4.0 license. */
 
 #define COPYTYPE cl_uint
 #define COPYTYPE_CL uint

--- a/test/copy_ulong.cpp
+++ b/test/copy_ulong.cpp
@@ -1,4 +1,4 @@
-/* TODO: Provide a license note */
+/* This project is licensed under the terms of the Creative Commons CC BY-NC-ND 4.0 license. */
 
 #define COPYTYPE cl_ulong
 #define COPYTYPE_CL ulong

--- a/test/copy_ushort.cpp
+++ b/test/copy_ushort.cpp
@@ -1,4 +1,4 @@
-/* TODO: Provide a license note */
+/* This project is licensed under the terms of the Creative Commons CC BY-NC-ND 4.0 license. */
 
 #define COPYTYPE cl_ushort
 #define COPYTYPE_CL ushort

--- a/test/repetition_test.cpp
+++ b/test/repetition_test.cpp
@@ -1,0 +1,110 @@
+/* This project is licensed under the terms of the Creative Commons CC BY-NC-ND 4.0 license. */
+
+#include <fstream>
+#include <iostream>
+#include <string>
+
+#include "opencl_include.hpp"
+#include "util.hpp"
+#include "hdf5_io.hpp"
+
+
+using namespace std;
+
+
+int main(void)
+{
+  constexpr int LENGTH = 32;
+
+  string filename{"repetition_test.h5"};
+
+  if (fileExists(filename)) {
+    remove(filename.c_str());
+  }
+
+  // kernel
+  string kernel_url("add_one_kernel.cl");
+  ofstream kernel_file;
+  kernel_file.open(kernel_url);
+  kernel_file << "\n\
+#ifdef cl_khr_fp64\n\
+  #pragma OPENCL EXTENSION cl_khr_fp64 : enable\n\
+#else\n\
+  #error \"IEEE-754 double precision not supported by OpenCL implementation.\"\n\
+#endif\n\
+\n\
+kernel void add_one(global REAL* values)\n\
+{\n\
+  const int gid = get_global_id(0);\n\
+  values[gid] += 1;\n\
+}\n\
+" << endl;
+  kernel_file.close();
+
+  h5_write_string(filename.c_str(), "Kernel_Settings", "-DREAL=ulong");
+  h5_write_string(filename.c_str(), "Kernel_URL", kernel_url.c_str());
+  vector<string> kernels(1, string("add_one"));
+  h5_write_strings(filename.c_str(), "Kernels", kernels);
+  cl_ulong kernel_repetitions = 5;
+  h5_write_single<cl_ulong>(filename.c_str(), "Kernel_Repetitions", kernel_repetitions);
+
+  // ranges
+  cl_ulong tmp_range[3];
+  tmp_range[0] = LENGTH; tmp_range[1] = 1; tmp_range[2] = 1;
+  h5_write_buffer<cl_ulong>(filename.c_str(), "Global_Range", tmp_range, 3);
+
+  tmp_range[0] = 0; tmp_range[1] = 0; tmp_range[2] = 0;
+  h5_write_buffer<cl_ulong>(filename.c_str(), "Local_Range", tmp_range, 3);
+  h5_write_buffer<cl_ulong>(filename.c_str(), "Range_Start", tmp_range, 3);
+
+  // data
+  vector<cl_ulong> values(LENGTH);
+  for (cl_ulong i = 0; i < LENGTH; ++i) {
+    values.at(i) = i;
+  }
+
+  h5_create_dir(filename.c_str(), "/Data");
+  h5_write_buffer<cl_ulong>(filename.c_str(), "Data/values", &values[0], LENGTH);
+
+
+  // call toolkitICL
+  string command("toolkitICL -c ");
+  command.append(filename);
+  int retval = system(command.c_str());
+  if (retval) {
+    cerr << "Error: " << retval << endl;
+    return 1;
+  }
+
+
+  // check result
+  string out_filename("out_");
+  out_filename.append(filename);
+  vector<cl_ulong> values_test(LENGTH);
+
+  if (!fileExists(out_filename)) {
+    cerr << "Error: File " << out_filename << " not found." << endl;
+    return 1;
+  }
+
+  h5_read_buffer<cl_ulong>(out_filename.c_str(), "Data/values", &values_test[0]);
+  for (size_t idx = 0; idx < LENGTH; ++idx) {
+    if (values_test[idx] != values[idx] + kernel_repetitions) {
+      cerr << "Error: Result 'values[" << idx << "] == " << values_test[idx] << "' is not as expected [" << values[idx] + kernel_repetitions << "]." << endl;
+      return 1;
+    }
+  }
+
+  //TODO: possible cleanup?
+  // if (fileExists(kernel_url)) {
+  //   remove(kernel_url.c_str());
+  // }
+  // if (fileExists(filename)) {
+  //   remove(filename.c_str());
+  // }
+  // if (fileExists(out_filename)) {
+  //   remove(out_filename.c_str());
+  // }
+
+  return 0;
+}

--- a/test/timer.cpp
+++ b/test/timer.cpp
@@ -1,4 +1,4 @@
-/* TODO: Provide a license note */
+/* This project is licensed under the terms of the Creative Commons CC BY-NC-ND 4.0 license. */
 
 #include <algorithm>
 #include <functional>


### PR DESCRIPTION
In most of our use cases, a fixed order of kernels is executed multiple times. In order to save some space and make the underlying structure more clear, I've added a configuration parameter `Kernel_Repetitions` with default value 1.

I've also added license notes to the test files.