### PR TITLE
fix getOS on Debian

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -183,6 +183,10 @@ std::string getOS()
 
     rel_file.close();
   }
+  else {
+       version << "Unknown Distribution";
+       }
+
   version << "/" << unameData.release << "/" << unameData.version;
 
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -171,13 +171,15 @@ std::string getOS()
 
   version << unameData.sysname << " ";
 
-  ifstream rel_file ("/etc/os-release");
+  ifstream rel_file("/etc/os-release");
   if (rel_file.is_open()) {
-    for (unsigned int i = 0; i < 5; i++) {
-      getline (rel_file,line);
+    while (rel_file.good()) {
+      getline(rel_file, line);
+      if (line.size() >= 1 && line.substr(0,11) == "PRETTY_NAME") {
+        version << line.substr(13, line.length()-14);
+        break;
+      }
     }
-
-    version << line.substr(13,line.length()-14);
 
     rel_file.close();
   }


### PR DESCRIPTION
The order of the lines in `/etc/os-release` does not seem to be the same across all linux distributions. On Debian, `toolkitICL` failed because of that, since the line `getOS` wants to read os not long enough:
```
$ cat /etc/os-release 
PRETTY_NAME="Debian GNU/Linux 9 (stretch)"
NAME="Debian GNU/Linux"
VERSION_ID="9"
VERSION="9 (stretch)"
ID=debian
HOME_URL="https://www.debian.org/"
SUPPORT_URL="https://www.debian.org/support"
BUG_REPORT_URL="https://bugs.debian.org/"
```
I've fixed that. Now, all tests pass again on Debian.