### PR TITLE
enable a description as optional string attribute

### DIFF
--- a/include/hdf5_io.hpp
+++ b/include/hdf5_io.hpp
@@ -45,12 +45,12 @@ inline bool h5_read_buffer(std::string const& filename, char const* varname, TYP
 
 // write a buffer to an HDF5 file using compression
 template<typename TYPE>
-bool h5_write_buffer(char const* filename, char const* varname, TYPE const* data, size_t size);
+bool h5_write_buffer(char const* filename, char const* varname, TYPE const* data, size_t size, std::string const& description="");
 
 template<typename TYPE>
-inline bool h5_write_buffer(std::string const& filename, char const* varname, TYPE const* data, size_t size)
+inline bool h5_write_buffer(std::string const& filename, char const* varname, TYPE const* data, size_t size, std::string const& description="")
 {
-  return h5_write_buffer<TYPE>(filename.c_str(), varname, data, size);
+  return h5_write_buffer<TYPE>(filename.c_str(), varname, data, size, description);
 }
 
 
@@ -71,12 +71,12 @@ inline TYPE h5_read_single(std::string const& filename, char const* varname)
 
 // write a single item to an HDF5 file
 template<typename TYPE>
-bool h5_write_single(char const* filename, char const* varname, TYPE data);
+bool h5_write_single(char const* filename, char const* varname, TYPE data, std::string const& description="");
 
 template<typename TYPE>
-inline bool h5_write_single(std::string const& filename, char const* varname, TYPE data)
+inline bool h5_write_single(std::string const& filename, char const* varname, TYPE data, std::string const& description="")
 {
-  return h5_write_single<TYPE>(filename.c_str(), varname, data);
+  return h5_write_single<TYPE>(filename.c_str(), varname, data, description);
 }
 
 

--- a/src/hdf5_io.cpp
+++ b/src/hdf5_io.cpp
@@ -260,7 +260,7 @@ template bool h5_read_buffer(char const* filename, char const* varname, cl_ulong
 
 // write a buffer to an HDF5 file using compression
 template<typename TYPE>
-bool h5_write_buffer(char const* filename, char const* varname, TYPE const* data, size_t size)
+bool h5_write_buffer(char const* filename, char const* varname, TYPE const* data, size_t size, std::string const& description)
 {
   hid_t   h5_file_id, dataset_id, dataspace_id, memspace_id;
   hsize_t hdf_dims[2];
@@ -292,6 +292,10 @@ bool h5_write_buffer(char const* filename, char const* varname, TYPE const* data
   // The same can be done using H5 High Level API, but without compression
   // H5LTmake_dataset(h5_file_id, varname, 2, hdf_dims, type_to_h5_type<TYPE>(), data);
 
+  if (!description.empty()) {
+    H5LTset_attribute_string(h5_file_id, varname, "description", description.c_str());
+  }
+
   H5Pclose(plist_id);
   H5Sclose(dataspace_id);
   H5Sclose(memspace_id);
@@ -303,16 +307,16 @@ bool h5_write_buffer(char const* filename, char const* varname, TYPE const* data
 }
 
 // template instantiations
-template bool h5_write_buffer(char const* filename, char const* varname, float const* data, size_t size);
-template bool h5_write_buffer(char const* filename, char const* varname, double const* data, size_t size);
-template bool h5_write_buffer(char const* filename, char const* varname, cl_char const* data, size_t size);
-template bool h5_write_buffer(char const* filename, char const* varname, cl_uchar const* data, size_t size);
-template bool h5_write_buffer(char const* filename, char const* varname, cl_short const* data, size_t size);
-template bool h5_write_buffer(char const* filename, char const* varname, cl_ushort const* data, size_t size);
-template bool h5_write_buffer(char const* filename, char const* varname, cl_int const* data, size_t size);
-template bool h5_write_buffer(char const* filename, char const* varname, cl_uint const* data, size_t size);
-template bool h5_write_buffer(char const* filename, char const* varname, cl_long const* data, size_t size);
-template bool h5_write_buffer(char const* filename, char const* varname, cl_ulong const* data, size_t size);
+template bool h5_write_buffer(char const* filename, char const* varname, float const* data, size_t size, std::string const& description);
+template bool h5_write_buffer(char const* filename, char const* varname, double const* data, size_t size, std::string const& description);
+template bool h5_write_buffer(char const* filename, char const* varname, cl_char const* data, size_t size, std::string const& description);
+template bool h5_write_buffer(char const* filename, char const* varname, cl_uchar const* data, size_t size, std::string const& description);
+template bool h5_write_buffer(char const* filename, char const* varname, cl_short const* data, size_t size, std::string const& description);
+template bool h5_write_buffer(char const* filename, char const* varname, cl_ushort const* data, size_t size, std::string const& description);
+template bool h5_write_buffer(char const* filename, char const* varname, cl_int const* data, size_t size, std::string const& description);
+template bool h5_write_buffer(char const* filename, char const* varname, cl_uint const* data, size_t size, std::string const& description);
+template bool h5_write_buffer(char const* filename, char const* varname, cl_long const* data, size_t size, std::string const& description);
+template bool h5_write_buffer(char const* filename, char const* varname, cl_ulong const* data, size_t size, std::string const& description);
 
 
 
@@ -325,7 +329,7 @@ template bool h5_write_buffer(char const* filename, char const* varname, cl_ulon
 
 // write a single item to an HDF5 file
 template<typename TYPE>
-bool h5_write_single(char const* filename, char const* varname, TYPE data)
+bool h5_write_single(char const* filename, char const* varname, TYPE data, std::string const& description)
 {
   hid_t h5_file_id;
 
@@ -338,22 +342,26 @@ bool h5_write_single(char const* filename, char const* varname, TYPE data)
 
   H5LTmake_dataset(h5_file_id, varname, 0, NULL, type_to_h5_type<TYPE>(), &data);
 
+  if (!description.empty()) {
+    H5LTset_attribute_string(h5_file_id, varname, "description", description.c_str());
+  }
+
   H5Fclose(h5_file_id);
 
   return true;
 }
 
 // template instantiations
-template bool h5_write_single(char const* filename, char const* varname, float data);
-template bool h5_write_single(char const* filename, char const* varname, double data);
-template bool h5_write_single(char const* filename, char const* varname, cl_char data);
-template bool h5_write_single(char const* filename, char const* varname, cl_uchar data);
-template bool h5_write_single(char const* filename, char const* varname, cl_short data);
-template bool h5_write_single(char const* filename, char const* varname, cl_ushort data);
-template bool h5_write_single(char const* filename, char const* varname, cl_int data);
-template bool h5_write_single(char const* filename, char const* varname, cl_uint data);
-template bool h5_write_single(char const* filename, char const* varname, cl_long data);
-template bool h5_write_single(char const* filename, char const* varname, cl_ulong data);
+template bool h5_write_single(char const* filename, char const* varname, float data, std::string const& description);
+template bool h5_write_single(char const* filename, char const* varname, double data, std::string const& description);
+template bool h5_write_single(char const* filename, char const* varname, cl_char data, std::string const& description);
+template bool h5_write_single(char const* filename, char const* varname, cl_uchar data, std::string const& description);
+template bool h5_write_single(char const* filename, char const* varname, cl_short data, std::string const& description);
+template bool h5_write_single(char const* filename, char const* varname, cl_ushort data, std::string const& description);
+template bool h5_write_single(char const* filename, char const* varname, cl_int data, std::string const& description);
+template bool h5_write_single(char const* filename, char const* varname, cl_uint data, std::string const& description);
+template bool h5_write_single(char const* filename, char const* varname, cl_long data, std::string const& description);
+template bool h5_write_single(char const* filename, char const* varname, cl_ulong data, std::string const& description);
 
 
 // reading and writing single strings

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -481,14 +481,17 @@ int main(int argc, char *argv[]) {
   cl_int tmp_range[3];
   h5_read_buffer<cl_int>(filename, "Global_Range", tmp_range);
   global_range = cl::NDRange(tmp_range[0], tmp_range[1], tmp_range[2]);
-  h5_write_buffer<cl_int>(out_name, "Global_Range", tmp_range, 3);
+  h5_write_buffer<cl_int>(out_name, "Global_Range", tmp_range, 3,
+                          "Argument `global_work_size` of the OpenCL function `clEnqueueNDRangeKernel`.");
 
   h5_read_buffer<cl_int>(filename, "Range_Start", tmp_range);
   range_start = cl::NDRange(tmp_range[0], tmp_range[1], tmp_range[2]);
-  h5_write_buffer<cl_int>(out_name, "Range_Start", tmp_range, 3);
+  h5_write_buffer<cl_int>(out_name, "Range_Start", tmp_range, 3,
+                          "Argument `global_work_offset` of the OpenCL function `clEnqueueNDRangeKernel`.");
 
   h5_read_buffer<cl_int>(filename, "Local_Range", tmp_range);
-  h5_write_buffer<cl_int>(out_name, "Local_Range", tmp_range, 3);
+  h5_write_buffer<cl_int>(out_name, "Local_Range", tmp_range, 3,
+                          "Argument `local_work_size` of the OpenCL function `clEnqueueNDRangeKernel`.");
   if ((tmp_range[0]==0) && (tmp_range[1]==0) && (tmp_range[2]==0)) {
     local_range = cl::NullRange;
   }
@@ -532,7 +535,8 @@ int main(int argc, char *argv[]) {
   }
 
   total_exec_time = timer.getTimeMicroseconds() - total_exec_time;
-  h5_write_single<double>(out_name, "Total_ExecTime", (double)total_exec_time / 1000.0);
+  h5_write_single<double>(out_name, "Total_ExecTime", (double)total_exec_time / 1000.0,
+                          "Time in milliseconds of the total execution (data transfer, kernel, and host code).");
 
 
   cout << "Kernels executed: " << kernels_run << endl;
@@ -599,8 +603,10 @@ int main(int argc, char *argv[]) {
   h5_write_string(out_name, "Kernel_ExecStart", time_buffer);
   h5_write_string(out_name, "OpenCL_Device", dev_mgr.get_avail_dev_info(deviceIndex).name.c_str());
   h5_write_string(out_name, "OpenCL_Version", dev_mgr.get_avail_dev_info(deviceIndex).ocl_version.c_str());
-  h5_write_single<double>(out_name,"Kernel_ExecTime", (double)exec_time/1000.0);
-  h5_write_single<double>(out_name, "Data_LoadTime", (double)push_time/1000.0);
+  h5_write_single<double>(out_name, "Kernel_ExecTime", (double)exec_time/1000.0,
+                          "Time in milliseconds of the kernel execution (no host code).");
+  h5_write_single<double>(out_name, "Data_LoadTime", (double)push_time/1000.0,
+                          "Time in milliseconds of the data transfer: hdf5 input file -> host -> device.");
 
   h5_create_dir(out_name, "/Data");
 
@@ -661,7 +667,8 @@ int main(int argc, char *argv[]) {
   }
 
   pull_time = timer.getTimeMicroseconds() - pull_time;
-  h5_write_single<double>(out_name, "Data_StoreTime", (double)pull_time / 1000.0);
+  h5_write_single<double>(out_name, "Data_StoreTime", (double)pull_time / 1000.0,
+                          "Time in milliseconds of the data transfer: device -> host -> hdf5 output file.");
 
   return 0;
 }


### PR DESCRIPTION
I've implemented the possibility to add a string as description of scalars and buffers. That should be sufficient for many use cases, I hope.