### PR TITLE
adapt RAPL to Mac OS X

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,11 +6,11 @@ PROJECT(toolkitICL)
 option(BUILDREL "Official release build" OFF)
 
 if(DEFINED ENV{AMDPROFILERPATH})
-    message(STATUS "Found AMD profiling driver")
-    option(USEAMDP "Use AMD Profiling" ON)
-    add_definitions(-DUSEAMDP)
+  message(STATUS "Found AMD profiling driver")
+  option(USEAMDP "Use AMD Profiling" ON)
+  add_definitions(-DUSEAMDP)
 ELSE()
-    option(USEAMDP "Use AMD Profiling" OFF)
+  option(USEAMDP "Use AMD Profiling" OFF)
 endif()
 
 find_package(CUDA)
@@ -21,23 +21,24 @@ ELSE()
   option(USENVML "Use NVML" OFF)
 ENDIF()
 
-IF(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-option(USEIRAPL "Use RAPL" OFF)
+
+IF(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC" OR APPLE)
+  option(USEIRAPL "Use RAPL" OFF)
 ELSE()
-option(USEIRAPL "Use RAPL" ON)
+  option(USEIRAPL "Use RAPL" ON)
 ENDIF()
 
-if(DEFINED ENV{IPG_Dir})
-    message(STATUS "Found Intel Power Gadget Driver")
+IF(DEFINED ENV{IPG_Dir} OR EXISTS "/Library/Frameworks/IntelPowerGadget.framework")
+  message(STATUS "Found Intel Power Gadget Driver")
 	option(USEIPG "Use Intel Power Gadget" ON)
-	option(USEIRAPL "Use RAPL" OFF)
 ELSE()
 	option(USEIPG "Use Intel Power Gadget" OFF)
-endif()
+ENDIF()
 
 IF(USEIPG)
   MESSAGE(STATUS "Using Intel Power Gadget")
   add_definitions(-DUSEIPG)
+	option(USEIRAPL "Use RAPL" OFF)
 ENDIF()
 
 
@@ -110,6 +111,10 @@ IF(APPLE)
   # Apple does not distribute a cl2.hpp include file and uses another default path for OpenCL
   FILE(DOWNLOAD ${CL2_URL} ${CMAKE_CURRENT_SOURCE_DIR}/include/OpenCL/cl2.hpp)
   SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -framework OpenCL")
+
+  IF(USEIPG)
+    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -F/Library/Frameworks -framework IntelPowerGadget")
+  ENDIF()
 ENDIF()
 
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ To build toolkitCL the following needs to be installed:
 
 For optional power and temperature logging, the following is needed:
 - CUDA Toolkit (only for NVidia GPU power/temperature logging)
-- Intel Power Gadget (only for Intel CPU/GPU power/temperature logging on Windows systems)
+- Intel Power Gadget (only for Intel CPU/GPU power/temperature logging on Windows and Mac OS X systems)
 - AMD µProf (only for AMD CPU/GPU power/temperature logging on Windows and Linux systems)
 
 This project uses the common CMake build system. Thus, the following commands can be used on Linux.

--- a/include/rapl.hpp
+++ b/include/rapl.hpp
@@ -52,7 +52,30 @@ public:
     bool GetPowerData(int iNode, int iMSR, double *results, int *nResult);
 };
 
-#else
+#elif defined(USEIPG) /* Mac OS */
+
+#include <unistd.h>
+
+class Rapl {
+private:
+  bool pp1_supported = false;
+  bool socket1_detected = false;
+
+public:
+  Rapl();
+  bool detect_igp();
+  bool detect_socket1();
+  uint32_t get_TDP();
+  int32_t get_NumMSR();
+  bool GetMsrName(int iMsr, char *pszName);
+  bool GetMsrFunc(int iMsr, int *funcID);
+  void sample();
+  int32_t get_temp0();
+  int32_t get_temp1();
+  bool GetPowerData(int iNode, int iMSR, double *results, int *nResult);
+};
+
+#else /* probably Linux */
 
 #include <unistd.h>
 #include <cstdint>


### PR DESCRIPTION
Closes #29.

As far as I know, we cannot use AMD μProf on Mac OS X, since that OS is not supported.